### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,2 +1,2 @@
 CT_URL=http://mymachine:9000
-LOCAL_URL=http://mymachine:3000
+LOCAL_URL=http://mymachine:7948


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Use correct port in dev.env.sample